### PR TITLE
Gérer plusieurs compteurs

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -66,7 +66,7 @@ try {
             sandbox: { type: 'boolean' }, // For test purposes
         },
     });
-} catch (e) {
+} catch (e: any) {
     exit(e);
     process.exit(1);
 }
@@ -75,6 +75,7 @@ const meteringFlags: MeteringFlags = {
     start: cli.flags.start,
     end: cli.flags.end,
     output: cli.flags.output || null,
+    usagePointId: cli.flags.usagePointId,
 };
 
 const notifier = updateNotifier({ pkg });

--- a/bin/store.ts
+++ b/bin/store.ts
@@ -4,23 +4,26 @@ const store = new Conf();
 
 const accessTokenStoreKey = 'linky/accessToken';
 const refreshTokenStoreKey = 'linky/refreshToken';
-const usagePointIDStoreKey = 'linky/usagePointId';
+const lastUsagePointIDStoreKey = 'linky/usagePointId';
 const failedRefreshAttemptsKey = 'linky/failedRefreshAttempts';
 const sandboxStoreKey = 'linky/sandbox';
 
-export const getAccessToken: () => string = () => store.get(accessTokenStoreKey, '') as string;
-export const getRefreshToken: () => string = () => store.get(refreshTokenStoreKey, '') as string;
-export const getUsagePointID: () => string = () => store.get(usagePointIDStoreKey, '') as string;
-export const getFailedRefreshAttempts: () => number = () => store.get(failedRefreshAttemptsKey, 0) as number;
+export const getAccessToken: (prm: string) => string = (prm) => store.get(accessTokenStoreKey + prm, '') as string;
+export const getRefreshToken: (prm: string) => string = (prm) => store.get(refreshTokenStoreKey + prm, '') as string;
+export const getLastUsagePointID: () => string = () => store.get(lastUsagePointIDStoreKey, '') as string;
+export const getFailedRefreshAttempts: (prm: string) => number = (prm) =>
+    store.get(failedRefreshAttemptsKey + prm, 0) as number;
 export const getSandbox: () => boolean = () => Boolean(store.get(sandboxStoreKey, false));
 
-export const setAccessToken = (accessToken: string) => store.set(accessTokenStoreKey, accessToken);
-export const setRefreshToken = (refreshToken: string) => store.set(refreshTokenStoreKey, refreshToken);
-export const setUsagePointID = (usagePointID: string) => store.set(usagePointIDStoreKey, usagePointID);
-export const setFailedRefreshAttempts = (attempts: number) => store.set(failedRefreshAttemptsKey, attempts);
-export const incrementFailedRefreshAttempts: () => number = () => {
-    let attempts = getFailedRefreshAttempts();
-    store.set(failedRefreshAttemptsKey, attempts + 1);
+export const setAccessToken = (accessToken: string, prm: string) => store.set(accessTokenStoreKey + prm, accessToken);
+export const setRefreshToken = (refreshToken: string, prm: string) =>
+    store.set(refreshTokenStoreKey + prm, refreshToken);
+export const setLastUsagePointID = (usagePointID: string) => store.set(lastUsagePointIDStoreKey, usagePointID);
+export const setFailedRefreshAttempts = (attempts: number, prm: string) =>
+    store.set(failedRefreshAttemptsKey + prm, attempts);
+export const incrementFailedRefreshAttempts: (prm: string) => number = (prm) => {
+    const attempts = getFailedRefreshAttempts(prm);
+    store.set(failedRefreshAttemptsKey + prm, attempts + 1);
     return attempts + 1;
 };
 export const setSandbox = (sandbox: boolean) => store.set(sandboxStoreKey, sandbox);


### PR DESCRIPTION
Bonjour,
Pour gérer plusieurs compteurs en ligne de commande, je propose d'associer l'identifiant du compteur à la clé de stockage des tokens.

Pour sélectionner un compteur, il suffit de le spécifier avec `-u identifiant`