### PR TITLE
Ajoute les drapeaux --quiet et --format

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -2,7 +2,7 @@
 
 import meow from 'meow';
 import { auth } from './auth';
-import { daily, dailyProduction, loadCurve, loadCurveProduction, maxPower, MeteringFlags } from './metering';
+import { daily, dailyProduction, loadCurve, loadCurveProduction, maxPower, MeteringFlags, Format } from './metering';
 import chalk from 'chalk';
 import updateNotifier from 'update-notifier';
 import dayjs from 'dayjs';
@@ -37,6 +37,8 @@ const mainHelp = `
         --start             -s    Date de début (AAAA-MM-JJ). Par défaut: hier
         --end               -e    Date de début (AAAA-MM-JJ). Par défaut: aujourd'hui
         --usage-point-id    -u    Usage Point ID (PRM). Par défaut: le dernier utilisé
+        --format            -f    Determine le format d'affichage de sortie du script. Options: pretty, json. Par défaut: pretty
+        --quiet             -q    N'affiche pas les messages et animations de progression. Optionnel
         --output            -o    Fichier .json de sortie. Optionnel
         
     Exemples:
@@ -69,6 +71,8 @@ try {
             start: { type: 'string', alias: 's', default: yesterday },
             end: { type: 'string', alias: 'e', default: today },
             output: { type: 'string', alias: 'o' },
+            format: { type: 'string', alias: 'f', default: 'pretty' },
+            quiet: { type: 'boolean', alias: 'q', default: false },
             sandbox: { type: 'boolean' }, // For test purposes
         },
     });
@@ -81,6 +85,8 @@ const meteringFlags: MeteringFlags = {
     start: cli.flags.start,
     end: cli.flags.end,
     output: cli.flags.output || null,
+    quiet: cli.flags.quiet,
+    format: cli.flags.format as Format,
     usagePointId: cli.flags.usagePointId,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,11 +76,11 @@ export class Session {
         }
     }
 
-    getDailyConsumption(start: string, end: string): Promise<Consumption> {
+    getDailyConsumption(start: string, end: string) {
         return this.request('daily_consumption', start, end);
     }
 
-    getLoadCurve(start: string, end: string): Promise<Consumption> {
+    getLoadCurve(start: string, end: string) {
         return this.request('consumption_load_curve', start, end);
     }
 


### PR DESCRIPTION
Cette PR répond à l'issue https://github.com/bokub/linky/issues/37 en ajoutant les options `--quiet` et `--format`.

- `--quiet` permet de cacher tout message et animation dans la sortie.
- `--format` permet de spécifier un autre format de sortie, soit `pretty`, le comportement par défaut, soit `json`.


```
$: linky daily -qf json
{
  "unit": "Wh",
  "data": [
    {
      "date": "2022-10-01",
      "value": 12268
    }
  ]
}
```

```
$: linky daily -q

Date        Valeur (Wh) Graphique
2022-10-01  12268       ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■

```

```
$: linky daily -qo daily.json
$: cat daily.json
{
  "unit": "Wh",
  "data": [
    {
      "date": "2022-10-01",
      "value": 12268
    }
  ]
}
```

La PR ajoute également les définitions de types pour les réponse Axios (peut être déplacé dans une autre PR si besoin) 