### PR TITLE
Modern node support

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16, 18]
+        node: [16, 18, 20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,9 +7,16 @@ import { join } from 'path';
 import { describe, expect, it, test, beforeAll } from 'vitest';
 process.env.FORCE_COLOR = '0';
 
+const isNode16 = process.version.startsWith('v16');
 const bin = './bin/cli.ts';
 const linky = (args: string) =>
-  node(bin, args.split(' '), { nodeOptions: ['--experimental-vm-modules', '--loader=ts-node/esm'] });
+  node(bin, args.split(' '), {
+    nodeOptions: [
+      isNode16 ? '' : '--import=./test/fixtures/fixtures.cjs',
+      '--experimental-vm-modules',
+      '--loader=ts-node/esm',
+    ].filter(Boolean),
+  });
 
 const validToken = jwt.sign({ sub: ['11111111111111'] }, 'secret');
 const invalidToken = jwt.sign({ sub: ['99999999999999'] }, 'secret');

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -2,10 +2,6 @@ import { APIError, Session } from '../lib/index.js';
 import jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import('./fixtures/fixtures.cjs');
-
 const session = new Session(jwt.sign({ sub: ['11111111111111'] }, 'secret'));
 
 describe('Linky module', () => {


### PR DESCRIPTION
This fixes #69 by using https://nodejs.org/docs/latest/api/module.html#modulecreaterequirefilename to be able to require package.json without having to worry about node version.

Also this is fixing the tests for node > 16 (they work locally at least) and while at it, I also remove the useless import (already done in the vite test config)