### PR TITLE
fix DEP0190 warning

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  ignorePatterns: ['cli.cjs'],
   env: {
     browser: false,
     es2021: true,

--- a/cli.cjs
+++ b/cli.cjs
@@ -2,7 +2,7 @@
 const { spawnSync } = require('child_process');
 const { resolve } = require('path');
 
-const cmd = 'node --no-warnings ' + resolve(__dirname, 'cli.js');
-const { status } = spawnSync(cmd, process.argv.slice(2), { stdio: 'inherit', shell: true });
+const args = [resolve(__dirname, 'cli.js'), ...process.argv.slice(2)];
+const { status } = spawnSync(process.execPath, args, { stdio: 'inherit' });
 
 process.exitCode = status;


### PR DESCRIPTION
Corrige [DEP0190 (dépréciation introduite avec Node.js 24)](https://nodejs.org/api/deprecations.html#dep0190-passing-args-to-nodechild-process-execfilespawn-with-shell-option-true), en supprimant `shell: true` lors du spawn du processus Node dans le wrapper CLI.

<img width="1329" height="151" alt="image" src="https://github.com/user-attachments/assets/e58d343a-1795-4f96-b769-3848fc368f02" />
