### PR TITLE
refactor: remove qs dependency

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosError } from 'axios';
-import qs from 'qs';
 import jwt from 'jsonwebtoken';
 
 const API_HOST = 'https://conso.boris.sh';
@@ -106,7 +105,7 @@ export class Session {
   }
 
   private callApi<T>(type: DataType, start: string, end: string): Promise<T> {
-    const url = `${API_HOST}/api/${type}?${qs.stringify({
+    const url = `${API_HOST}/api/${type}?${new URLSearchParams({
       start: start,
       end: end,
       prm: this.prm || this.prms[0],

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "meow": "^12.0.0",
         "mkdirp": "^3.0.1",
         "ora": "^6.3.0",
-        "qs": "^6.11.1",
         "update-notifier": "^6.0.2"
       },
       "bin": {
@@ -26,7 +25,6 @@
       "devDependencies": {
         "@bokub/prettier-config": "^2.1.0",
         "@types/jsonwebtoken": "^9.0.2",
-        "@types/qs": "^6.9.7",
         "@types/update-notifier": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
@@ -1193,12 +1191,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
-    },
     "node_modules/@types/semver": {
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
@@ -2050,18 +2042,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3270,19 +3250,6 @@
         "node": "*"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -3429,17 +3396,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-yarn": {
@@ -5065,20 +5021,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/qs": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5543,19 +5485,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {

--- a/package.json
+++ b/package.json
@@ -37,13 +37,11 @@
     "meow": "^12.0.0",
     "mkdirp": "^3.0.1",
     "ora": "^6.3.0",
-    "qs": "^6.11.1",
     "update-notifier": "^6.0.2"
   },
   "devDependencies": {
     "@bokub/prettier-config": "^2.1.0",
     "@types/jsonwebtoken": "^9.0.2",
-    "@types/qs": "^6.9.7",
     "@types/update-notifier": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",


### PR DESCRIPTION
J'utilise linky sur un projet perso où dependabot est configuré pour mettre à jour les dépendances et éventuellement corriger des problèmes de sécurité en forçant certaines mises à jours de dépendances et c'est le cas avec la version de qs en dépendance du projet qui [a une petite faille de sécurité](https://github.com/advisories/GHSA-6rw7-vpxm-498p).

Mais bon, `qs` est très rarement vraiment nécessaire et dans linky clairement  URLSearchParams disponible sans dépendance permet de faire la même chose donc autant juste s'en débarrasser.